### PR TITLE
Fix show platform ssdhealth not showing expected output when a usb flash drive is plugged in for some platforms

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -117,11 +117,13 @@ def ssdhealth(device, verbose, vendor):
         if platform_data:
             device = platform_data.get("chassis", {}).get("disk", {}).get("device", None)
 
-        if not device:
-            # Fallback to discovery
-            device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]
+    # if device argument is not provided ssdutil will display the health of the disk containing
+    # the /host partition. In sonic this is the primary storage device.
+    if device:
+        cmd = ['sudo', 'ssdutil', '-d', str(device)]
+    else:
+        cmd = ['sudo', 'ssdutil']
 
-    cmd = ['sudo', 'ssdutil', '-d', str(device)]
     options = ["-v"] if verbose else []
     options += ["-e"] if vendor else []
     clicommon.run_command(cmd + options, display_cmd=verbose)

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -98,21 +98,17 @@ class TestShowPlatformSsdhealth(object):
         assert mock_run_command.call_count == 1
         mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)
 
-    @mock.patch('os.popen')
     @mock.patch('utilities_common.cli.run_command')
     @mock.patch('sonic_py_common.device_info.get_platform_json_data')
-    def test_ssdhealth_default_device(self, mock_plat_json, mock_run_command, mock_open):
+    def test_ssdhealth_default_device(self, mock_plat_json, mock_run_command):
         mock_plat_json.return_value = {
             "chassis": {
                  "name": "mock_platform"
             }
         }
-        mock_fd = mock.MagicMock()
-        mock_fd.readline.return_value = "/dev/nvme0n1     disk\n"
-        mock_open.return_value = mock_fd
+
         CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose'])
-        mock_open.assert_called_with("lsblk -o NAME,TYPE -p | grep disk")
-        mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)
+        mock_run_command.assert_called_with(['sudo', 'ssdutil', '-v'], display_cmd=True)
 
         mock_plat_json.return_value = {
             "chassis": {

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -686,21 +686,18 @@ class TestShowPlatform(object):
 
     @mock.patch('sonic_py_common.device_info.get_platform_json_data')
     @patch('utilities_common.cli.run_command')
-    @patch('os.popen')
-    def test_ssdhealth(self, mock_popen, mock_run_command, mock_plat_json):
+    def test_ssdhealth(self, mock_run_command, mock_plat_json):
         mock_plat_json.return_value = {
             "chassis": {
                  "name": "mock_platform"
             }
         }
-        mock_popen.return_value.readline.return_value = '/dev/sda\n'
         runner = CliRunner()
         result = runner.invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose', '--vendor'])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        mock_popen.assert_called_once_with('lsblk -o NAME,TYPE -p | grep disk')
-        mock_run_command.assert_called_once_with(['sudo', 'ssdutil', '-d', '/dev/sda', '-v', '-e'], display_cmd=True)
+        mock_run_command.assert_called_once_with(['sudo', 'ssdutil', '-v', '-e'], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')
     def test_pcieinfo(self, mock_run_command):


### PR DESCRIPTION
Fix `show platform ssdhealth` not showing expected output when a usb flash drive is plugged in. 

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When 'show platform ssdhealth' is not supplied with a device name and a usb flash drive is attached we show incorrect output as we deduce incorrect device name from 'lsblk' command and pass it to ssdutil. I removed this incorrect deduction of the device name.

#### How I did it

Instead of incorrectly deducing the device using the lsblk command we can instead not pass any device name as argument to the ssdutil and it will automatically choose the device on which /host partition is mounted which is the primary storage device in our case as per the PR: https://github.com/sonic-net/sonic-utilities/pull/3399

#### How to verify it

Run `sudo show platform ssdhealth` without any arguments with a flash drive plugged into the sonic switch. 


#### Previous command output (if the output of a command-line utility has changed)

```
root@qa-eth-vt19-1-4280:~# show platform ssdhealth
Disk Type    : NVME
Device Model : N/A
Health       : N/A
Temperature  : N/A
```

#### New command output (if the output of a command-line utility has changed)

```
root@qa-eth-vt19-1-4280:/home/admin# show platform ssdhealth
Disk Type    : NVME
Device Model : Virtium VTPM24CEXI080-BM110006
Health       : 100.0%
Temperature  : 51.0C
```

In the case where the user passes the device name as argument to the command (`show platform ssdhealth /dev/nvme0n1`) output remains the same and no changes have been made.


