### PR TITLE
Fix docker id parsing for auto techsupport to work

### DIFF
--- a/scripts/coredump-compress
+++ b/scripts/coredump-compress
@@ -9,7 +9,7 @@ done
 
 CONTAINER_ID=""
 if [ $# > 0 ]; then
-    CONTAINER_ID=$(xargs -0 -L1 -a /proc/${1}/cgroup | grep -oP "pids:/docker/\K\w+")
+    CONTAINER_ID=$(xargs -0 -L1 -a /proc/${1}/cgroup | grep -oP "system.slice/docker-\K\w+")
     ns=`xargs -0 -L1 -a /proc/${1}/environ | grep -e "^NAMESPACE_ID" | cut -f2 -d'='`
     if [ ! -z ${ns} ]; then
         PREFIX=${PREFIX}${ns}.


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix the auto-techsupport feature in trixie

```
root@bookworm:/home/admin# xargs -0 -L1 -a /proc/21435/cgroup
12:pids:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
11:cpuset:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
10:perf_event:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
9:freezer:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
8:hugetlb:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
7:memory:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
6:rdma:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
5:misc:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
4:devices:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
3:blkio:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
2:cpu,cpuacct:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
1:name=systemd:/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1
0::/docker/9c53b4bb9687130724b138cea69f72e0ea325e80ce66a12ce35853b72bc113a1

root@trixie:/home/admin# cat /proc/11982/cgroup
0::/system.slice/docker-57dd3ffc993e6a8476c358022367d5de032c2280144590ac5438526de391ff5d.scope
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

