### PR TITLE
Use Singleton PlatformDataProvider to reduce module import time in fwutil

### DIFF
--- a/fwutil/main.py
+++ b/fwutil/main.py
@@ -37,8 +37,17 @@ ROOT_UID = 0
 
 # ========================= Variables ==========================================
 
-pdp = PlatformDataProvider()
+# Lazily initialize PlatformDataProvider to avoid expensive platform probing on import
+_pdp = None
 log_helper = LogHelper()
+
+
+def get_pdp():
+    """Singleton accessor to defer platform initialization until first use."""
+    global _pdp
+    if _pdp is None:
+        _pdp = PlatformDataProvider()
+    return _pdp
 
 # ========================= Helper functions ===================================
 
@@ -98,6 +107,7 @@ def all_update(ctx):
 
 
 def chassis_handler(ctx):
+    pdp = get_pdp()
     ctx.obj[CHASSIS_NAME_CTX_KEY] = pdp.chassis.get_name()
     ctx.obj[COMPONENT_PATH_CTX_KEY].append(pdp.chassis.get_name())
 
@@ -119,12 +129,14 @@ def chassis_update(ctx):
 
 
 def module_handler(ctx, module_name):
+    pdp = get_pdp()
     ctx.obj[MODULE_NAME_CTX_KEY] = module_name
     ctx.obj[COMPONENT_PATH_CTX_KEY].append(pdp.chassis.get_name())
     ctx.obj[COMPONENT_PATH_CTX_KEY].append(module_name)
 
 
 def validate_module(ctx, param, value):
+    pdp = get_pdp()
     if value == HELP:
         cli_show_help(ctx)
 
@@ -160,6 +172,7 @@ def component_handler(ctx, component_name):
 
 
 def validate_component(ctx, param, value):
+    pdp = get_pdp()
     if value == HELP:
         cli_show_help(ctx)
 
@@ -296,6 +309,7 @@ def fw_update(ctx, yes, force, image):
         chassis_name = ctx.obj[CHASSIS_NAME_CTX_KEY]
         module_name = None
     elif MODULE_NAME_CTX_KEY in ctx.obj:
+        pdp = get_pdp()
         chassis_name = pdp.chassis.get_name()
         module_name = ctx.obj[MODULE_NAME_CTX_KEY]
 


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
For `fwutil show` command which displays the usage/help message reduce the time taken by lazily importing PlatformDataProvider. This reduced the average time taken by ~50%.

#### How I did it
Use a singleton PlatformDataProvider in fwutil/main.py
#### How to verify it
Before the change
```
Running 'fwutil show' 10 times (gap 5s)...
Run 1: 972 ms
Run 2: 1058 ms
Run 3: 948 ms
Run 4: 1213 ms
Run 5: 1507 ms
Run 6: 1235 ms
Run 7: 1553 ms
Run 8: 1037 ms
Run 9: 1000 ms
Run 10: 1037 ms
---- fwutil show stats ----
Avg: 1156 ms
Min: 948 ms
Max: 1553 ms
```
After the change
```
Running 'fwutil show' 10 times (gap 5s)...
Run 1: 496 ms
Run 2: 482 ms
Run 3: 466 ms
Run 4: 445 ms
Run 5: 482 ms
Run 6: 463 ms
Run 7: 780 ms
Run 8: 662 ms
Run 9: 653 ms
Run 10: 659 ms
---- fwutil show stats ----
Avg: 558 ms
Min: 445 ms
Max: 780 ms
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

