### PR TITLE
Wait for monit monitor <service> operation to complete during config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1043,6 +1043,26 @@ def wait_service_restart_finish(service, last_timestamp, timeout=30):
     log.log_warning("Service: {} does not restart in {} seconds, stop waiting".format(service, timeout))
 
 
+def _wait_for_monit_service_monitored(service, timeout=10):
+    """Poll monit status until the service leaves 'Not monitored' state.
+    Because monit monitor <service> is asynchronous — it returns before the action
+    completes.
+    """
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        output, ret = clicommon.run_command(
+            ['sudo', 'monit', 'status', service], return_cmd=True
+        )
+        if ret == 0:
+            for line in output.splitlines():
+                if 'monitoring status' in line.lower():
+                    if 'not monitored' not in line.lower():
+                        return
+                    break
+        time.sleep(0.1)
+    log.log_error("Monit monitor action for '{}' did not complete within {} seconds".format(service, timeout))
+
+
 def _restart_services():
     last_interface_config_timestamp = get_service_finish_timestamp('interfaces-config')
     last_networking_timestamp = get_service_finish_timestamp('networking')
@@ -1060,7 +1080,9 @@ def _restart_services():
         click.echo("Enabling container and routeCheck monitoring ...")
         clicommon.run_command(['sudo', 'monit', 'monitor', 'routeCheck'])
         clicommon.run_command(['sudo', 'monit', 'monitor', 'container_checker'])
-        time.sleep(1)
+        log.log_notice("Waiting for monit monitor actions to complete ...")
+        _wait_for_monit_service_monitored('routeCheck')
+        _wait_for_monit_service_monitored('container_checker')
     except subprocess.CalledProcessError as err:
         pass
     # Reload Monit configuration to pick up new hostname in case it changed

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -325,6 +325,8 @@ def mock_run_command_side_effect(*args, **kwargs):
             return f'{datetime.datetime.now()}', 0
         elif command == 'sudo systemctl show --no-pager networking -p ExecMainExitTimestamp --value':
             return f'{datetime.datetime.now()}', 0
+        elif command.startswith('sudo monit status'):
+            return '  monitoring status            Monitored\n', 0
         else:
             return '', 0
 
@@ -1067,7 +1069,7 @@ class TestLoadMinigraph(object):
                 (load_minigraph_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 19
+            assert mock_run_command.call_count == 21
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
                 mock.MagicMock(return_value=("dummy_path", None)))


### PR DESCRIPTION
Fixes Sonic Bug: Race condition in enabling monitoring during config reload #25599

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Wait for monit monitor <service> operation to complete before monit reload operation

#### Why I did
There is a race condition in the implementation of config reload in sonic code. 

During config reload -y -f we ask monit to unmonitor container_checker to avoid errors as containers go down. And during restarting as part of the reload we ask monit to monitor container_checker again. For this we using "monit monitor container_checker" command. This is an async operation. Please see below 


https://github.com/sonic-net/sonic-utilities/blob/cbb31f0d65c6768107f2089f6c75a617d8b519b4/config/main.py#L1058C1-L1068C55

```
    try:
        subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
        click.echo("Enabling container and routeCheck monitoring ...")
        clicommon.run_command(['sudo', 'monit', 'monitor', 'routeCheck'])
        clicommon.run_command(['sudo', 'monit', 'monitor', 'container_checker'])
        time.sleep(1)
    except subprocess.CalledProcessError as err:
        pass
    # Reload Monit configuration to pick up new hostname in case it changed
    click.echo("Reloading Monit configuration ...")
    clicommon.run_command(['sudo', 'monit', 'reload'])
```

During monit reload, monit saves and restores monitoring state and since container_checker was not enabled so it will forever remained unmonitored from this point onwards.

#### How I did it
Wait till monitor action is complete before monit reload

#### How to verify it
monit checkers will not be left in not monitored state after config reload