### PR TITLE
Fix config cli interval range validation

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3157,7 +3157,8 @@ def stop(verbose):
 
 @pfcwd.command()
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-@click.argument('poll_interval', type=click.IntRange(100, 3000))
+# Keep in sync with the pfcwd CLI validation and sonic-pfcwd YANG model.
+@click.argument('poll_interval', type=click.IntRange(100, 1000))
 def interval(poll_interval, verbose):
     """ Set PFC watchdog counter polling interval (ms) """
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Aligned config pfcwd interval argument validation with the updated pfcwd CLI and sonic-pfcwd YANG constraints by changing the allowed POLL_INTERVAL max from 3000 to 1000 in sonic-utilities/config/main.py.

#### How I did it
Updated the Click argument type for config pfcwd interval from click.IntRange(100, 3000) to click.IntRange(100, 1000) so the wrapper rejects invalid values consistently instead of passing them down to pfcwd and producing mismatched errors.
#### How to verify it
Run config pfcwd interval 3001
#### Previous command output (if the output of a command-line utility has changed)

```
root@sonic:/home/admin# config pfcwd interval 3001
Usage: config pfcwd interval [OPTIONS] POLL_INTERVAL
Try 'config pfcwd interval -h' for help.

Error: Invalid value for 'POLL_INTERVAL': 3001 is not in the range 100<=x<=3000.
root@sonic:/home/admin# config pfcwd interval 1001
Usage: pfcwd interval [OPTIONS] POLL_INTERVAL
Try 'pfcwd interval --help' for help.

Error: Invalid value for 'POLL_INTERVAL': 1001 is not in the range 100<=x<=1000.
```
#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# config pfcwd interval 1001
Usage: config pfcwd interval [OPTIONS] POLL_INTERVAL
Try 'config pfcwd interval -h' for help.

Error: Invalid value for 'POLL_INTERVAL': 1001 is not in the range 100<=x<=1000.
root@sonic:/home/admin# config pfcwd interval 3001
Usage: config pfcwd interval [OPTIONS] POLL_INTERVAL
Try 'config pfcwd interval -h' for help.

Error: Invalid value for 'POLL_INTERVAL': 3001 is not in the range 100<=x<=1000.

```
