### PR TITLE
Disable Scapy route autoload in teamd retry-count script to reduce warm-reboot delays

### DIFF
--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -13,6 +13,10 @@ import sys
 import time
 
 from swsscommon.swsscommon import ConfigDBConnector
+from scapy.config import conf
+# Avoid long startup delays when route tables are large.
+conf.route_autoload = False
+conf.route6_autoload = False
 from scapy.all import *
 
 

--- a/scripts/teamd_increase_retry_count.py
+++ b/scripts/teamd_increase_retry_count.py
@@ -4,6 +4,9 @@ import subprocess
 import json
 from pyroute2 import netns
 from scapy.config import conf
+# Fixes delayed import when we have a lot of routes installed
+conf.route_autoload = False
+conf.route6_autoload = False
 import os
 import re
 import sys


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix scapy import delay in teamd_increase_retry_count.py script when there are a lot of routes installed
#### How I did it
Turn off scapy to autoload routes
#### why I did it
This is because scapy 2.6.1 in Debian 13 tries to create internal python objects for all the routes in route table. This process can take long time when we have a lot of routes installed thus breaching the 30sec timeout limit set in warm-reboot script.


