### PR TITLE
Fix docker daemon crash during package migration due to -H fd://

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -312,7 +312,10 @@ def get_docker_opts():
         pid = int(pid_file.read())
 
     with open("/proc/{}/cmdline".format(pid)) as cmdline_file:
-        return cmdline_file.read().strip().split("\x00")[1:]
+        opts = cmdline_file.read().strip().split("\x00")[1:]
+        # Replace fd:// with unix:// to ensure dockerd can start properly
+        # inside a chroot environment without systemd socket activation
+        return [opt if opt != "fd://" else "unix://" for opt in opts]
 
 
 def migrate_sonic_packages(bootloader, binary_image_version):

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -26,7 +26,7 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
     new_image_folder = f"/images/{new_image_version}"
     image_docker_folder = os.path.join(new_image_folder, "docker")
     mounted_image_folder = f"/tmp/image-{new_image_version}-fs"
-    dockerd_opts = ["--iptables=false", "--bip=1.1.1.1/24"]
+    dockerd_opts = ["--iptables=false", "--bip=1.1.1.1/24", "-H", "fd://"]
 
     # Setup mock files needed for our test scenario
     fs.create_file(sonic_image_filename)
@@ -34,6 +34,9 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
     fs.create_dir(os.path.join(mounted_image_folder, "usr/lib/docker/docker.sh"))
     fs.create_file("/var/run/docker.pid", contents="15")
     fs.create_file("/proc/15/cmdline", contents="\x00".join(["dockerd"] + dockerd_opts))
+
+    # Expect fd:// to be replaced by unix://
+    expected_dockerd_opts = [opt if opt != "fd://" else "unix://" for opt in dockerd_opts]
 
     # Setup bootloader mock
     mock_bootloader = Mock()
@@ -83,7 +86,7 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
         call(["chroot", mounted_image_folder, "mount", "proc", "/proc", "-t", "proc"]),
         call(["chroot", mounted_image_folder, "mount", "sysfs", "/sys", "-t", "sysfs"]),
         call(["cp", f"{mounted_image_folder}/etc/default/docker", f"{mounted_image_folder}/tmp/docker_config_backup"]),
-        call(["sh", "-c", f"echo 'DOCKER_OPTS=\"$DOCKER_OPTS {' '.join(dockerd_opts)}\"' >> {mounted_image_folder}/etc/default/docker"]), # dockerd started with added options as host dockerd
+        call(["sh", "-c", f"echo 'DOCKER_OPTS=\"$DOCKER_OPTS {' '.join(expected_dockerd_opts)}\"' >> {mounted_image_folder}/etc/default/docker"]), # dockerd started with added options as host dockerd
         call(["chroot", mounted_image_folder, "/usr/lib/docker/docker.sh", "start"]),
         call(["cp", "/var/lib/sonic-package-manager/packages.json", f"{mounted_image_folder}/tmp/packages.json"]),
         call(["mkdir", "-p", "/var/lib/sonic-package-manager/manifests"]),
@@ -163,7 +166,7 @@ def test_install_failed(rmtree, run_command, run_command_or_raise, get_bootloade
     new_image_folder = f"/images/{new_image_version}"
     image_docker_folder = os.path.join(new_image_folder, "docker")
     mounted_image_folder = f"/tmp/image-{new_image_version}-fs"
-    dockerd_opts = ["--iptables=false", "--bip=1.1.1.1/24"]
+    dockerd_opts = ["--iptables=false", "--bip=1.1.1.1/24", "-H", "fd://"]
 
     # Setup mock files needed for our test scenario
     fs.create_file(sonic_image_filename)

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -86,7 +86,12 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
         call(["chroot", mounted_image_folder, "mount", "proc", "/proc", "-t", "proc"]),
         call(["chroot", mounted_image_folder, "mount", "sysfs", "/sys", "-t", "sysfs"]),
         call(["cp", f"{mounted_image_folder}/etc/default/docker", f"{mounted_image_folder}/tmp/docker_config_backup"]),
-        call(["sh", "-c", f"echo 'DOCKER_OPTS=\"$DOCKER_OPTS {' '.join(expected_dockerd_opts)}\"' >> {mounted_image_folder}/etc/default/docker"]), # dockerd started with added options as host dockerd
+        # dockerd started with unix:// instead of fd://
+        call([
+            "sh", "-c",
+            f"echo 'DOCKER_OPTS=\"$DOCKER_OPTS {' '.join(expected_dockerd_opts)}\"' "
+            f">> {mounted_image_folder}/etc/default/docker"
+        ]),
         call(["chroot", mounted_image_folder, "/usr/lib/docker/docker.sh", "start"]),
         call(["cp", "/var/lib/sonic-package-manager/packages.json", f"{mounted_image_folder}/tmp/packages.json"]),
         call(["mkdir", "-p", "/var/lib/sonic-package-manager/manifests"]),


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did
PR #25398 changed the host's Docker config to use -H fd://. During image installation, sonic-installer copies these host options to run a temporary dockerd inside a chroot. Since systemd isn't running in the chroot to create and handover a socket dockerd crashes, causing sonic-package-manager migrate to fail.

#### What I did
Sanitized the copied DOCKER_OPTS so the temporary dockerd can start safely without systemd socket activation.
#### How I did it
- In sonic_installer/main.py (get_docker_opts), replaced fd:// with unix://.
- Updated mock arguments in test_sonic_installer.py to verify the sanitization logic.

#### How to verify it

Run sudo sonic-installer install <image.bin> and verify the installation completes successfully without failing during the package migration step.

