### PR TITLE
Fix false positive "static route still bound to RIF" due to substring match on interface name

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5629,7 +5629,8 @@ def remove(ctx, interface_name, ip_addr):
             # If there is output data, check is there a static route,
             # bound to the interface.
             if output != "":
-                if any(interface_name in output_line for output_line in output.splitlines()):
+                if any(re.search(r'\b{}\b'.format(re.escape(interface_name)), output_line)
+                       for output_line in output.splitlines()):
                     ctx.fail("Cannot remove the last IP entry of interface {}. A static {} route is still bound to the RIF.".format(interface_name, ip_ver))
     if multi_asic.is_multi_asic():
         command = ['sudo', 'ip', 'netns', 'exec', str(ctx.obj['namespace']), 'ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]

--- a/config/main.py
+++ b/config/main.py
@@ -5627,11 +5627,18 @@ def remove(ctx, interface_name, ip_addr):
             else:
                 output = bgp_util.run_bgp_command(cmd)
             # If there is output data, check is there a static route,
-            # bound to the interface.
+            # bound to the interface.  Works with sub-interfaces as
+            # "." is treated as part of the name (avoids Ethernet0 matching
+            # Ethernet0.10) and digits are not truncated (avoids Ethernet24
+            # matching Ethernet240).
             if output != "":
-                if any(re.search(r'\b{}\b'.format(re.escape(interface_name)), output_line)
-                       for output_line in output.splitlines()):
-                    ctx.fail("Cannot remove the last IP entry of interface {}. A static {} route is still bound to the RIF.".format(interface_name, ip_ver))
+                intf_pattern = re.compile(
+                    r'(?<![\w.]){}(?![\w.])'.format(re.escape(interface_name)))
+                if intf_pattern.search(output):
+                    ctx.fail(
+                        "Cannot remove the last IP entry of interface {}."
+                        " A static {} route is still bound to the RIF."
+                        .format(interface_name, ip_ver))
     if multi_asic.is_multi_asic():
         command = ['sudo', 'ip', 'netns', 'exec', str(ctx.obj['namespace']), 'ip', 'neigh', 'flush', 'dev', str(interface_name), str(ip_address)]
     else:

--- a/tests/config_int_ip_common.py
+++ b/tests/config_int_ip_common.py
@@ -13,6 +13,8 @@ S>* 0.0.0.0/0 [200/0] via 192.168.111.3, eth0, weight 1, 19:51:57
 S>* 20.0.0.1/32 [1/0] is directly connected, Ethernet4 (vrf Vrf11), weight 1, 00:38:52
 S>* 20.0.0.4/32 [1/0] is directly connected, PortChannel2, weight 1, 00:38:52
 S>* 20.0.0.8/32 [1/0] is directly connected, Vlan2, weight 1, 00:38:52
+S>* 20.0.0.16/32 [1/0] is directly connected, Ethernet16.16, weight 1, 00:38:52
+S>* 20.0.0.24/32 [1/0] is directly connected, Ethernet240, weight 1, 00:38:52
 """
 
 show_ipv6_route_with_static_expected_output = """\

--- a/tests/config_int_ip_common.py
+++ b/tests/config_int_ip_common.py
@@ -13,7 +13,7 @@ S>* 0.0.0.0/0 [200/0] via 192.168.111.3, eth0, weight 1, 19:51:57
 S>* 20.0.0.1/32 [1/0] is directly connected, Ethernet4 (vrf Vrf11), weight 1, 00:38:52
 S>* 20.0.0.4/32 [1/0] is directly connected, PortChannel2, weight 1, 00:38:52
 S>* 20.0.0.8/32 [1/0] is directly connected, Vlan2, weight 1, 00:38:52
-S>* 20.0.0.16/32 [1/0] is directly connected, Ethernet16.16, weight 1, 00:38:52
+S>* 20.0.0.6/32 [1/0] is directly connected, Ethernet6.10, weight 1, 00:38:52
 S>* 20.0.0.24/32 [1/0] is directly connected, Ethernet240, weight 1, 00:38:52
 """
 

--- a/tests/config_int_ip_test.py
+++ b/tests/config_int_ip_test.py
@@ -116,12 +116,12 @@ class TestIntIp(object):
             assert result.exit_code == 0
             assert mock_run_command.call_count == 1
 
-        # Ethernet16 has a single IP and no static route bound to it.
-        # A static route exists via subinterface Ethernet16.16.  Verify
-        # the match does not treat "Ethernet16" as matching "Ethernet16.16".
+        # Ethernet6 has a single IP and no static route bound to it.
+        # A static route exists via subinterface Ethernet6.10.  Verify
+        # the match does not treat "Ethernet6" as matching "Ethernet6.10".
         with mock.patch('utilities_common.cli.run_command') as mock_run_command:
             result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"],
-                                   ["Ethernet16", "192.168.10.1/24"], obj=obj)
+                                   ["Ethernet6", "192.168.6.1/24"], obj=obj)
             print(result.exit_code, result.output)
             assert result.exit_code == 0
             assert mock_run_command.call_count == 1

--- a/tests/config_int_ip_test.py
+++ b/tests/config_int_ip_test.py
@@ -105,6 +105,27 @@ class TestIntIp(object):
             assert result.exit_code == 0
             assert mock_run_command.call_count == 1
 
+        # Ethernet24 has a single IP and no static route bound to it.
+        # A static route exists via Ethernet240.  Verify the interface
+        # name match does not treat "Ethernet24" as a substring of
+        # "Ethernet240".
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"],
+                                   ["Ethernet24", "192.168.24.1/24"], obj=obj)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            assert mock_run_command.call_count == 1
+
+        # Ethernet16 has a single IP and no static route bound to it.
+        # A static route exists via subinterface Ethernet16.16.  Verify
+        # the match does not treat "Ethernet16" as matching "Ethernet16.16".
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"],
+                                   ["Ethernet16", "192.168.10.1/24"], obj=obj)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            assert mock_run_command.call_count == 1
+
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['ip_route_for_int_ip'], indirect=['setup_single_bgp_instance'])
     def test_config_int_ip_rem_sub_intf(

--- a/tests/int_ip_input/config_db.json
+++ b/tests/int_ip_input/config_db.json
@@ -26,6 +26,12 @@
     "INTERFACE|Ethernet8|192.168.3.1/24": {
         "NULL": "NULL"
     },
+    "INTERFACE|Ethernet24": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet24|192.168.24.1/24": {
+        "NULL": "NULL"
+    },
     "PORTCHANNEL_INTERFACE|PortChannel2": {
         "NULL": "NULL"
     },

--- a/tests/int_ip_input/config_db.json
+++ b/tests/int_ip_input/config_db.json
@@ -26,6 +26,12 @@
     "INTERFACE|Ethernet8|192.168.3.1/24": {
         "NULL": "NULL"
     },
+    "INTERFACE|Ethernet6": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet6|192.168.6.1/24": {
+        "NULL": "NULL"
+    },
     "INTERFACE|Ethernet24": {
         "NULL": "NULL"
     },


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did
config interface ip remove falsely blocks IP removal when the target interface name is a substring of another interface that has a static route. For example, removing the last IP from Ethernet24 fails because "Ethernet24" in "...Ethernet240..." evaluates to True.
```
# Given: static route already exists via Ethernet240
admin@sonic:~$ show ip route vrf all static | grep Ethernet240
S>* 10.1.0.7/32 [1/0] via 18.2.202.1, Ethernet240, weight 1, 1d15h47m

# Remove IPv4 so IPv6 becomes the last IP on Ethernet24
admin@sonic:~$ sudo config interface ip remove Ethernet24 10.0.0.44/31

# Try to remove the last IP from Ethernet24
admin@sonic:~$ sudo config interface ip remove Ethernet24 FC00::59/126
Error: Cannot remove the last IP entry of interface Ethernet24. A static ip route is still bound to the RIF.
```

Despite the above error - No static route is bound to Ethernet24 -- the route is on Ethernet240.

#### What I did/How I did it
Replaced the Python in substring check with a regex word-boundary (\b) match when validating whether a static route references the interface being modified.


#### How to verify it
Before fix
```
admin@sonic:~$ sudo config interface ip remove Ethernet24 10.0.0.44/31
admin@sonic:~$ sudo config interface ip remove Ethernet24 FC00::59/126
Usage: config interface ip remove [OPTIONS] <interface_name> <ip_addr>
Try 'config interface ip remove -h' for help.

Error: Cannot remove the last IP entry of interface Ethernet24. A static ip route is still bound to the RIF.
```

After Fix
```
admin@sonic:~$ sudo config interface ip remove Ethernet24 10.0.0.44/31
admin@sonic:~$ sudo config interface ip remove Ethernet24 FC00::59/126
admin@sonic:~$
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

